### PR TITLE
Techdocs to be run locally

### DIFF
--- a/roles/ocp4_workload_platform_engineering_workshop/templates/developer-hub/developer-hub-application.yaml.j2
+++ b/roles/ocp4_workload_platform_engineering_workshop/templates/developer-hub/developer-hub-application.yaml.j2
@@ -72,6 +72,12 @@ spec:
                         - allow: [{{ location.rules.allow }}]
 {% endfor %}
 
+                techdocs:
+                  builder: 'local'
+                  publisher:
+                    type: 'local'
+                  generator:
+                    runIn: local
                 argocd:
                   appLocatorMethods:
                     - type: 'config'


### PR DESCRIPTION
Allow techdocs to be fetched locally without getting deployed externally (e.g. AWS S3)